### PR TITLE
Implement hasNext flag

### DIFF
--- a/continuation-token/src/main/kotlin/net/sprd/common/continuationtoken/Model.kt
+++ b/continuation-token/src/main/kotlin/net/sprd/common/continuationtoken/Model.kt
@@ -20,7 +20,8 @@ data class QueryAdvice(
 
 data class Page<out P : Pageable>(
         val entities: List<P>,
-        val token: ContinuationToken?
+        val token: ContinuationToken?,
+        val hasNext: Boolean
 )
 
 interface Pageable {

--- a/continuation-token/src/main/kotlin/net/sprd/common/continuationtoken/Pagination.kt
+++ b/continuation-token/src/main/kotlin/net/sprd/common/continuationtoken/Pagination.kt
@@ -77,9 +77,9 @@ private fun <P : Pageable> checksumsAreUnequal(previousToken: ContinuationToken,
     return previousToken.checksum != createTokenFromEntities(checksumSlice)?.checksum
 }
 
-private fun <P : Pageable> createEmptyPage(token: ContinuationToken?): Page<P> = Page(listOf(), token, false)
-private fun <P : Pageable> createLastPage(entities: List<P>, token: ContinuationToken?): Page<P> = Page(entities, token, false)
-private fun <P : Pageable> createInitialPage(entities: List<P>, pageSize: Int): Page<P> = createOffsetPage(entities, 0, pageSize)
+private fun <P : Pageable> createEmptyPage(token: ContinuationToken?): Page<P> = Page(listOf(), token, hasNext = false)
+private fun <P : Pageable> createLastPage(entities: List<P>, token: ContinuationToken?): Page<P> = Page(entities, token, hasNext = false)
+private fun <P : Pageable> createInitialPage(entities: List<P>, pageSize: Int): Page<P> = createOffsetPage(entities, offset = 0, pageSize = pageSize)
 
 internal fun <P : Pageable> createOffsetPage(entities: List<P>, offset: Int, pageSize: Int): Page<P> {
     val entitiesOffset = skipOffset(entities, offset)

--- a/continuation-token/src/main/kotlin/net/sprd/common/continuationtoken/Pagination.kt
+++ b/continuation-token/src/main/kotlin/net/sprd/common/continuationtoken/Pagination.kt
@@ -16,7 +16,7 @@ import java.util.zip.CRC32
  */
 fun <P : Pageable> createPage(entities: List<P>, previousToken: ContinuationToken?, pageSize: Int): Page<P> {
     if (entities.isEmpty()) {
-        return createEmptyPage()
+        return createEmptyPage(previousToken)
     }
 
     if (previousToken == null) {
@@ -77,16 +77,16 @@ private fun <P : Pageable> checksumsAreUnequal(previousToken: ContinuationToken,
     return previousToken.checksum != createTokenFromEntities(checksumSlice)?.checksum
 }
 
-private fun <P : Pageable> createEmptyPage(): Page<P> = Page(listOf(), null)
-private fun <P : Pageable> createLastPage(entities: List<P>): Page<P> = Page(entities, null)
+private fun <P : Pageable> createEmptyPage(token: ContinuationToken?): Page<P> = Page(listOf(), token, false)
+private fun <P : Pageable> createLastPage(entities: List<P>, token: ContinuationToken?): Page<P> = Page(entities, token, false)
 private fun <P : Pageable> createInitialPage(entities: List<P>, pageSize: Int): Page<P> = createOffsetPage(entities, 0, pageSize)
 
 internal fun <P : Pageable> createOffsetPage(entities: List<P>, offset: Int, pageSize: Int): Page<P> {
     val entitiesOffset = skipOffset(entities, offset)
     if (isEndOfFeed(entitiesOffset, pageSize)) {
-        return createLastPage(entitiesOffset)
+        return createLastPage(entitiesOffset, createTokenFromEntities(entities))
     }
-    return Page(entitiesOffset, createTokenFromEntities(entities))
+    return Page(entitiesOffset, createTokenFromEntities(entities), hasNext = true)
 }
 
 private fun isEndOfFeed(entities: List<Pageable>, pageSize: Int) = entities.size < pageSize

--- a/continuation-token/src/test/kotlin/net/sprd/common/continuationtoken/PaginationTest.kt
+++ b/continuation-token/src/test/kotlin/net/sprd/common/continuationtoken/PaginationTest.kt
@@ -72,7 +72,7 @@ internal class PaginationTest {
             ))
 
             val entriesSinceKey = allEntries.getEntriesSinceIncluding(timestamp = 3, limit = 4)
-            val page2 = createPage(entriesSinceKey, page.token, 3)
+            val page2 = createPage(entriesSinceKey, page.token, 4)
             assertThat(page2).isEqualTo(Page(
                     entities = listOf(
                             TestPageable("4", 3),

--- a/continuation-token/src/test/kotlin/net/sprd/common/continuationtoken/PaginationTest.kt
+++ b/continuation-token/src/test/kotlin/net/sprd/common/continuationtoken/PaginationTest.kt
@@ -31,7 +31,8 @@ internal class PaginationTest {
                             TestPageable(2),
                             TestPageable(3)
                     ),
-                    token = ContinuationToken(timestamp = 3, offset = 1, checksum = checksum("3"))
+                    token = ContinuationToken(timestamp = 3, offset = 1, checksum = checksum("3")),
+                    hasNext = true
             ))
 
             val entriesSinceKey = allEntries.getEntriesSinceIncluding(timestamp = 3, limit = 4)
@@ -42,7 +43,8 @@ internal class PaginationTest {
                             TestPageable(5),
                             TestPageable(6)
                     ),
-                    token = ContinuationToken(timestamp = 6, offset = 1, checksum = checksum("6"))
+                    token = ContinuationToken(timestamp = 6, offset = 1, checksum = checksum("6")),
+                    hasNext = true
             ))
         }
 
@@ -65,7 +67,8 @@ internal class PaginationTest {
                             TestPageable("2", 2),
                             TestPageable("3", 3)
                     ),
-                    token = ContinuationToken(timestamp = 3, offset = 1, checksum = checksum("3"))
+                    token = ContinuationToken(timestamp = 3, offset = 1, checksum = checksum("3")),
+                    hasNext = true
             ))
 
             val entriesSinceKey = allEntries.getEntriesSinceIncluding(timestamp = 3, limit = 4)
@@ -76,7 +79,8 @@ internal class PaginationTest {
                             TestPageable("5", 5),
                             TestPageable("6", 6)
                     ),
-                    token = ContinuationToken(timestamp = 6, offset = 1, checksum = checksum("6"))
+                    token = ContinuationToken(timestamp = 6, offset = 1, checksum = checksum("6")),
+                    hasNext = false
             ))
         }
 
@@ -98,7 +102,8 @@ internal class PaginationTest {
                             TestPageable("2", 1),
                             TestPageable("3", 1)
                     ),
-                    token = ContinuationToken(timestamp = 1, offset = 3, checksum = checksum("1", "2", "3"))
+                    token = ContinuationToken(timestamp = 1, offset = 3, checksum = checksum("1", "2", "3")),
+                    hasNext = true
             ))
 
             val entriesSinceKey = allEntries.getEntriesSinceIncluding(timestamp = 1, limit = 6)
@@ -109,12 +114,13 @@ internal class PaginationTest {
                             TestPageable("5", 1),
                             TestPageable("6", 1)
                     ),
-                    token = ContinuationToken(timestamp = 1, offset = 6, checksum = checksum("1", "2", "3", "4", "5", "6"))
+                    token = ContinuationToken(timestamp = 1, offset = 6, checksum = checksum("1", "2", "3", "4", "5", "6")),
+                    hasNext = true
             ))
         }
 
         @Test
-        fun `|1,2,3|| although it's the last page it fits right into the page size so we can't tell if this is the last page and have to pass a next token`() {
+        fun `|1,2,3|| check if token and hasNext is set if entities fit exactly into last page`() {
             val allEntries = listOf(
                     TestPageable(1),
                     TestPageable(2),
@@ -129,19 +135,21 @@ internal class PaginationTest {
                             TestPageable(2),
                             TestPageable(3)
                     ),
-                    token = ContinuationToken(timestamp = 3, offset = 1, checksum = checksum("3"))
+                    token = ContinuationToken(timestamp = 3, offset = 1, checksum = checksum("3")),
+                    hasNext = true
             ))
 
             val entriesSinceKey = allEntries.getEntriesSinceIncluding(timestamp = 3, limit = 3)
             val page2 = createPage(entriesSinceKey, page.token, 3)
             assertThat(page2).isEqualTo(Page(
                     entities = listOf(),
-                    token = null
+                    token = ContinuationToken(timestamp = 3, offset = 1, checksum = checksum("3")),
+                    hasNext = false
             ))
         }
 
         @Test
-        fun `|1,2| no next token if there are less elements than page size`() {
+        fun `|1,2| hasNext is false if there are less elements than page size`() {
             val allEntries = listOf(
                     TestPageable(1),
                     TestPageable(2)
@@ -154,7 +162,8 @@ internal class PaginationTest {
                             TestPageable(1),
                             TestPageable(2)
                     ),
-                    token = null
+                    token = ContinuationToken(timestamp = 2, offset = 1, checksum = checksum("2")),
+                    hasNext = false
             ))
         }
 
@@ -175,7 +184,8 @@ internal class PaginationTest {
                             TestPageable(2),
                             TestPageable(3)
                     ),
-                    token = ContinuationToken(timestamp = 3, offset = 1, checksum = checksum("3"))
+                    token = ContinuationToken(timestamp = 3, offset = 1, checksum = checksum("3")),
+                    hasNext = true
             ))
 
             val entriesSinceKey = allEntries.getEntriesSinceIncluding(timestamp = 3, limit = 3)
@@ -184,7 +194,8 @@ internal class PaginationTest {
                     entities = listOf(
                             TestPageable(4)
                     ),
-                    token = null
+                    token = ContinuationToken(timestamp = 4, offset = 1, checksum = checksum("4")),
+                    hasNext = false
             ))
         }
 
@@ -206,7 +217,8 @@ internal class PaginationTest {
                             TestPageable(2),
                             TestPageable(3)
                     ),
-                    token = ContinuationToken(timestamp = 3, offset = 1, checksum = checksum("3"))
+                    token = ContinuationToken(timestamp = 3, offset = 1, checksum = checksum("3")),
+                    hasNext = true
             ))
 
             val entriesSinceKey = allEntries.getEntriesSinceIncluding(timestamp = 3, limit = 3)
@@ -216,7 +228,8 @@ internal class PaginationTest {
                             TestPageable(4),
                             TestPageable(5)
                     ),
-                    token = null
+                    token = ContinuationToken(timestamp = 5, offset = 1, checksum = checksum(ids = "5")),
+                    hasNext = false
             ))
         }
 
@@ -225,7 +238,8 @@ internal class PaginationTest {
             val page = createPage(listOf(), null, 3)
             assertThat(page).isEqualTo(Page(
                     entities = listOf(),
-                    token = null
+                    token = null,
+                    hasNext = false
             ))
         }
 
@@ -248,7 +262,8 @@ internal class PaginationTest {
                             TestPageable("2", 3),
                             TestPageable("3", 3)
                     ),
-                    token = ContinuationToken(timestamp = 3, offset = 2, checksum = checksum("2", "3"))
+                    token = ContinuationToken(timestamp = 3, offset = 2, checksum = checksum("2", "3")),
+                    hasNext = true
             ))
 
             val entriesSinceKey = allEntries.getEntriesSinceIncluding(timestamp = 3, limit = 5)
@@ -259,7 +274,8 @@ internal class PaginationTest {
                             TestPageable("5", 5),
                             TestPageable("6", 6)
                     ),
-                    token = ContinuationToken(timestamp = 6, offset = 1, checksum = checksum("6"))
+                    token = ContinuationToken(timestamp = 6, offset = 1, checksum = checksum("6")),
+                    hasNext = true
             ))
         }
 
@@ -282,7 +298,8 @@ internal class PaginationTest {
                             TestPageable("2", 3),
                             TestPageable("3", 3)
                     ),
-                    token = ContinuationToken(timestamp = 3, offset = 2, checksum = checksum("2", "3"))
+                    token = ContinuationToken(timestamp = 3, offset = 2, checksum = checksum("2", "3")),
+                    hasNext = true
             ))
 
             val entriesSinceKey = allEntries.getEntriesSinceIncluding(timestamp = 3, limit = 5)
@@ -293,7 +310,8 @@ internal class PaginationTest {
                             TestPageable("5", 5),
                             TestPageable("6", 6)
                     ),
-                    token = ContinuationToken(timestamp = 6, offset = 1, checksum = checksum("6"))
+                    token = ContinuationToken(timestamp = 6, offset = 1, checksum = checksum("6")),
+                    hasNext = true
             ))
         }
 
@@ -316,7 +334,8 @@ internal class PaginationTest {
                             TestPageable("2", 3),
                             TestPageable("3", 3)
                     ),
-                    token = ContinuationToken(timestamp = 3, offset = 2, checksum = checksum("2", "3"))
+                    token = ContinuationToken(timestamp = 3, offset = 2, checksum = checksum("2", "3")),
+                    hasNext = true
             ))
 
             val entriesSinceKey = allEntries.getEntriesSinceIncluding(timestamp = 3, limit = 5)
@@ -327,7 +346,8 @@ internal class PaginationTest {
                             TestPageable("5", 3),
                             TestPageable("6", 6)
                     ),
-                    token = ContinuationToken(timestamp = 6, offset = 1, checksum = checksum("6"))
+                    token = ContinuationToken(timestamp = 6, offset = 1, checksum = checksum("6")),
+                    hasNext = true
             ))
         }
 
@@ -350,7 +370,8 @@ internal class PaginationTest {
                             TestPageable("2", 2),
                             TestPageable("3", 3)
                     ),
-                    token = ContinuationToken(timestamp = 3, offset = 1, checksum = checksum("3"))
+                    token = ContinuationToken(timestamp = 3, offset = 1, checksum = checksum("3")),
+                    hasNext = true
             ))
 
             val entriesSinceKey = allEntries.getEntriesSinceIncluding(timestamp = 3, limit = 5)
@@ -361,7 +382,8 @@ internal class PaginationTest {
                             TestPageable("5", 3),
                             TestPageable("6", 6)
                     ),
-                    token = ContinuationToken(timestamp = 6, offset = 1, checksum = checksum("6"))
+                    token = ContinuationToken(timestamp = 6, offset = 1, checksum = checksum("6")),
+                    hasNext = true
             ))
         }
 
@@ -384,7 +406,8 @@ internal class PaginationTest {
                             TestPageable("2", 2),
                             TestPageable("3", 3)
                     ),
-                    token = ContinuationToken(timestamp = 3, offset = 1, checksum = checksum("3"))
+                    token = ContinuationToken(timestamp = 3, offset = 1, checksum = checksum("3")),
+                    hasNext = true
             ))
 
             val entriesSinceKey = allEntries.getEntriesSinceIncluding(timestamp = 3, limit = 5)
@@ -395,7 +418,8 @@ internal class PaginationTest {
                             TestPageable("5", 4),
                             TestPageable("6", 6)
                     ),
-                    token = ContinuationToken(timestamp = 6, offset = 1, checksum = checksum("6"))
+                    token = ContinuationToken(timestamp = 6, offset = 1, checksum = checksum("6")),
+                    hasNext = true
             ))
         }
 
@@ -418,7 +442,8 @@ internal class PaginationTest {
                             TestPageable("2", 1),
                             TestPageable("3", 1)
                     ),
-                    token = ContinuationToken(timestamp = 1, offset = 3, checksum = checksum("1", "2", "3"))
+                    token = ContinuationToken(timestamp = 1, offset = 3, checksum = checksum("1", "2", "3")),
+                    hasNext = true
             ))
 
             val entriesSinceKey = allEntries.getEntriesSinceIncluding(timestamp = 1, limit = 6)
@@ -429,7 +454,8 @@ internal class PaginationTest {
                             TestPageable("5", 1),
                             TestPageable("6", 2)
                     ),
-                    token = ContinuationToken(timestamp = 2, offset = 1, checksum = checksum("6"))
+                    token = ContinuationToken(timestamp = 2, offset = 1, checksum = checksum("6")),
+                    hasNext = true
             ))
         }
     }
@@ -482,7 +508,8 @@ internal class PaginationTest {
                             TestPageable(2),
                             TestPageable(3)
                     ),
-                    token = ContinuationToken(timestamp = 3, offset = 1, checksum = checksum("3"))
+                    token = ContinuationToken(timestamp = 3, offset = 1, checksum = checksum("3")),
+                    hasNext = true
             ))
 
             allEntries.updateTimestampOfElement("3", 999)
@@ -495,7 +522,8 @@ internal class PaginationTest {
                             TestPageable(5),
                             TestPageable(6)
                     ),
-                    token = ContinuationToken(timestamp = 6, offset = 1, checksum = checksum("6"))
+                    token = ContinuationToken(timestamp = 6, offset = 1, checksum = checksum("6")),
+                    hasNext = true
             ))
 
             val entriesSinceKey2 = allEntries.getEntriesSinceIncluding(timestamp = 6, limit = 4)
@@ -505,7 +533,8 @@ internal class PaginationTest {
                             TestPageable(6),
                             TestPageable("3", 999)
                     ),
-                    token = null
+                    token = ContinuationToken(timestamp = 999, offset = 1, checksum = checksum("3")),
+                    hasNext = false
             ))
         }
 
@@ -527,7 +556,8 @@ internal class PaginationTest {
                             TestPageable("2", 2),
                             TestPageable("3", 3)
                     ),
-                    token = ContinuationToken(timestamp = 3, offset = 1, checksum = checksum("3"))
+                    token = ContinuationToken(timestamp = 3, offset = 1, checksum = checksum("3")),
+                    hasNext = true
             ))
 
             allEntries.updateTimestampOfElement("3", 999)
@@ -540,7 +570,8 @@ internal class PaginationTest {
                             TestPageable("5", 5),
                             TestPageable("3", 999)
                     ),
-                    token = ContinuationToken(timestamp = 999, offset = 1, checksum = checksum("3"))
+                    token = ContinuationToken(timestamp = 999, offset = 1, checksum = checksum("3")),
+                    hasNext = true
             ))
         }
 
@@ -562,7 +593,8 @@ internal class PaginationTest {
                             TestPageable("2", 2),
                             TestPageable("3", 3)
                     ),
-                    token = ContinuationToken(timestamp = 3, offset = 1, checksum = checksum("3"))
+                    token = ContinuationToken(timestamp = 3, offset = 1, checksum = checksum("3")),
+                    hasNext = true
             ))
 
             allEntries.updateTimestampOfElement("3", 999)
@@ -575,7 +607,8 @@ internal class PaginationTest {
                             TestPageable("5", 5),
                             TestPageable("3", 999)
                     ),
-                    token = ContinuationToken(timestamp = 999, offset = 1, checksum = checksum("3"))
+                    token = ContinuationToken(timestamp = 999, offset = 1, checksum = checksum("3")),
+                    hasNext = true
             ))
         }
 
@@ -598,7 +631,8 @@ internal class PaginationTest {
                             TestPageable("2", 1),
                             TestPageable("3", 1)
                     ),
-                    token = ContinuationToken(timestamp = 1, offset = 3, checksum = checksum("1", "2", "3"))
+                    token = ContinuationToken(timestamp = 1, offset = 3, checksum = checksum("1", "2", "3")),
+                    hasNext = true
             ))
 
             allEntries.updateTimestampOfElement("3", 999)
@@ -614,7 +648,8 @@ internal class PaginationTest {
                             TestPageable("6", 1),
                             TestPageable("3", 999)
                     ),
-                    token = ContinuationToken(timestamp = 999, offset = 1, checksum = checksum("3"))
+                    token = ContinuationToken(timestamp = 999, offset = 1, checksum = checksum("3")),
+                    hasNext = true
             ))
         }
 
@@ -635,7 +670,8 @@ internal class PaginationTest {
                             TestPageable("2", 3),
                             TestPageable("3", 3)
                     ),
-                    token = ContinuationToken(timestamp = 3, offset = 2, checksum = checksum("2", "3"))
+                    token = ContinuationToken(timestamp = 3, offset = 2, checksum = checksum("2", "3")),
+                    hasNext = true
             ))
 
             allEntries.updateTimestampOfElement("3", 999)
@@ -648,7 +684,8 @@ internal class PaginationTest {
                             TestPageable("4", 4),
                             TestPageable("3", 999)
                     ),
-                    token = ContinuationToken(timestamp = 999, offset = 1, checksum = checksum("3"))
+                    token = ContinuationToken(timestamp = 999, offset = 1, checksum = checksum("3")),
+                    hasNext = true
             ))
         }
 

--- a/demo-java/src/main/java/net/sprd/demo/pagination/EmployeePage.java
+++ b/demo-java/src/main/java/net/sprd/demo/pagination/EmployeePage.java
@@ -7,9 +7,11 @@ import java.util.List;
 public class EmployeePage {
     private final List<Employee> entities;
     private final String token;
+    private final boolean hasNext;
 
     public EmployeePage(Page<Employee> page) {
         this.entities = page.getEntities();
+        this.hasNext = page.getHasNext();
         this.token = (page.getToken() == null) ? null : page.getToken().toString();
     }
 
@@ -19,5 +21,9 @@ public class EmployeePage {
 
     public String getToken() {
         return token;
+    }
+
+    public boolean hasNext() {
+        return hasNext;
     }
 }

--- a/demo-java/src/test/java/net/sprd/demo/pagination/EmployeeResourceTest.java
+++ b/demo-java/src/test/java/net/sprd/demo/pagination/EmployeeResourceTest.java
@@ -15,7 +15,9 @@ import java.util.stream.IntStream;
 
 import static java.net.HttpURLConnection.HTTP_OK;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class EmployeeResourceTest {
     EmployeeResource resource;
@@ -37,6 +39,7 @@ class EmployeeResourceTest {
         assertNotNull(response.body());
         EmployeePage page = gson.fromJson(response.body(), EmployeePage.class);
         assertNotNull(page);
+        assertTrue(page.hasNext());
         assertNotNull(page.getToken());
         Streams.forEachPair(
                 IntStream.range(1, 10).boxed(),
@@ -46,14 +49,15 @@ class EmployeeResourceTest {
 
         // fetch second page
         response = RequestResponseFactory.create(new MockHttpServletResponse());
-        resource.handle(createRequest(10, page.getToken()), response);
+        resource.handle(createRequest(100, page.getToken()), response);
 
         assertEquals(HTTP_OK, response.status());
         assertNotNull(response.body());
         page = gson.fromJson(response.body(), EmployeePage.class);
         assertNotNull(page);
+        assertFalse(page.hasNext());
         Streams.forEachPair(
-                IntStream.range(11, 20).boxed(),
+                IntStream.range(11, 100).boxed(),
                 page.getEntities().stream(),
                 (id, entity) -> assertEquals(id.intValue(), entity.getId())
         );

--- a/demo-kotlin/src/main/kotlin/net/sprd/demo/pagination/DesignResource.kt
+++ b/demo-kotlin/src/main/kotlin/net/sprd/demo/pagination/DesignResource.kt
@@ -17,6 +17,7 @@ class DesignResource(private val dao: DesignDAO) {
         val dto = PageDTO(
                 designs = page.entities.map(::mapToDTO),
                 continuationToken = page.token?.toString(),
+                hasNext = page.hasNext,
                 nextPage = page.token?.let { "http://localhost:8000/designs?pageSize=$pageSize&continuationToken=${page.token}" }
         )
         return Response(Status.OK)
@@ -42,7 +43,8 @@ data class DesignDTO(
 data class PageDTO(
         val designs: List<DesignDTO>,
         val continuationToken: String?,
-        val nextPage: String?
+        val nextPage: String?,
+        val hasNext: Boolean
 )
 
 private val mapper = jacksonObjectMapper()

--- a/demo-kotlin/src/test/kotlin/net/sprd/demo/pagination/DesignResourceTest.kt
+++ b/demo-kotlin/src/test/kotlin/net/sprd/demo/pagination/DesignResourceTest.kt
@@ -30,6 +30,7 @@ internal class DesignResourceTest {
 
         val firstPage = firstPageResponse.toPageDTO()
         assertThat(firstPage.continuationToken).isNotNull()
+        assertThat(firstPage.hasNext).isTrue()
         assertThat(firstPage.nextPage).isNotNull()
         assertThat(firstPage.designs).containsExactly(
                 DesignDTO(id = "0", title = "Cat 0", imageUrl = "http://domain.de/cat0.jpg", dateModified = 1512757070)
@@ -39,8 +40,9 @@ internal class DesignResourceTest {
 
         val secondPageResponse = resource.getDesigns(Request(Method.GET, firstPage.nextPage!!))
         val secondPage = secondPageResponse.toPageDTO()
-        assertThat(secondPage.continuationToken).isNull()
-        assertThat(secondPage.nextPage).isNull()
+        assertThat(secondPage.continuationToken).isNotNull()
+        assertThat(secondPage.hasNext).isFalse()
+        assertThat(secondPage.nextPage).isNotNull()
         assertThat(secondPage.designs).containsExactly(
                 DesignDTO(id = "3", title = "Cat 3", imageUrl = "http://domain.de/cat3.jpg", dateModified = 1512757073)
                 , DesignDTO(id = "4", title = "Cat 4", imageUrl = "http://domain.de/cat4.jpg", dateModified = 1512757074)


### PR DESCRIPTION
This PR adds a new flag called `hasNext` to the `Page` that indicates that there are still entities left to fetch.
This also changes how continuation-tokens are handled at the end of a feed, i.e. a continuation-token is always returned except for an empty page without a previous token given.